### PR TITLE
docs:  changing the documentation, the installation instructions not right to close #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# keycloak-backend-ts
+# keycloak-middleware-ts
 
 [![codecov](https://codecov.io/gh/rafaelcascalho/keycloak-middleware-ts/branch/main/graph/badge.svg?token=L8LAFN62KQ)](https://codecov.io/gh/rafaelcascalho/keycloak-middleware-ts)
 
@@ -14,7 +14,7 @@ of authentication, token handling and user management. [Check more about keycloa
 ### Install Via NPM
 
 ```sh
-npm install -S keycloak-backend-ts
+npm install -S keycloak-middleware-ts
 ```
 
 ### Set Up Your Keycloak Realm and Client For The Backend
@@ -27,7 +27,7 @@ Just create a new keycloak context and use the methods of the lib API.
 
 ```js
 // import the createKeycloakCtx method from the module
-import createKeycloakCtx from "keycloak-backend-ts";
+import createKeycloakCtx from "keycloak-middleware-ts";
 
 // create the keycloak context
 const keycloak = createKeycloakCtx({


### PR DESCRIPTION
# Issue
In the documentation, the installation instruction is not right

In the document README.md it shows the instruction to install the library, but it is not published like this in NPM.

`npm install -S keycloak-backend-ts`

**To Reproduce**
Steps to reproduce the behavior:
1. Go to '/README.md'
2. See installation instruction

**What to do?**
Just change the package name according to what was published in NPM